### PR TITLE
refactor(819340): 动态表元数据刷新机制

### DIFF
--- a/src/main/java/com/codingapi/dbstream/DBStreamContext.java
+++ b/src/main/java/com/codingapi/dbstream/DBStreamContext.java
@@ -12,6 +12,8 @@ import com.codingapi.dbstream.event.DBEventPusher;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Properties;
 
@@ -132,6 +134,31 @@ public class DBStreamContext {
      */
     public void clear(String jdbcKey) {
         DBMetaContext.getInstance().clear(jdbcKey);
+    }
+
+    /**
+     * 刷新指定数据源中指定表的元数据。
+     * 适用于运行时动态创建或修改表结构后，手动触发元数据更新。
+     *
+     * @param connection 数据库连接
+     * @param jdbcKey    数据源唯一标识，可通过 {@link #loadDbKeys()} 获取
+     * @param tableName  需要刷新的表名称
+     * @throws SQLException 刷新失败时抛出
+     */
+    public void refreshTable(Connection connection, String jdbcKey, String tableName) throws SQLException {
+        DBMetaContext.getInstance().refreshTable(jdbcKey, connection, tableName);
+    }
+
+    /**
+     * 全量刷新指定数据源的元数据。
+     * 重新扫描所有表结构并更新缓存。
+     *
+     * @param connection 数据库连接
+     * @param jdbcKey    数据源唯一标识，可通过 {@link #loadDbKeys()} 获取
+     * @throws SQLException 刷新失败时抛出
+     */
+    public void refreshAll(Connection connection, String jdbcKey) throws SQLException {
+        DBMetaContext.getInstance().refreshAll(jdbcKey, connection);
     }
 
 

--- a/src/main/java/com/codingapi/dbstream/scanner/DBMetaContext.java
+++ b/src/main/java/com/codingapi/dbstream/scanner/DBMetaContext.java
@@ -2,6 +2,8 @@ package com.codingapi.dbstream.scanner;
 
 import lombok.Getter;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -86,6 +88,35 @@ public class DBMetaContext {
             dbMetaData.cleanSerializable();
         }
         cache.remove(jdbcKey);
+    }
+
+    /**
+     * 刷新指定数据源中指定表的元数据
+     *
+     * @param jdbcKey    数据源唯一标识
+     * @param connection 数据库连接
+     * @param tableName  表名称
+     * @throws SQLException SQLException
+     */
+    public void refreshTable(String jdbcKey, Connection connection, String tableName) throws SQLException {
+        DBMetaData metaData = cache.get(jdbcKey);
+        if (metaData != null) {
+            metaData.refreshTable(connection, tableName);
+        }
+    }
+
+    /**
+     * 全量刷新指定数据源的元数据
+     *
+     * @param jdbcKey    数据源唯一标识
+     * @param connection 数据库连接
+     * @throws SQLException SQLException
+     */
+    public void refreshAll(String jdbcKey, Connection connection) throws SQLException {
+        DBMetaData metaData = cache.get(jdbcKey);
+        if (metaData != null) {
+            metaData.refreshAll(connection);
+        }
     }
 
 }

--- a/src/main/java/com/codingapi/dbstream/scanner/DBMetaData.java
+++ b/src/main/java/com/codingapi/dbstream/scanner/DBMetaData.java
@@ -4,8 +4,10 @@ import com.codingapi.dbstream.proxy.ConnectionProxy;
 import com.codingapi.dbstream.serializable.DBTableSerializableHelper;
 import lombok.Getter;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.*;
+
 
 /**
  * 数据库所有表的元数据信息
@@ -196,5 +198,36 @@ public class DBMetaData {
             this.updateDbTable(tables);
             this.success();
         }
+    }
+
+    /**
+     * 刷新指定表的元数据
+     *
+     * @param connection 数据库连接
+     * @param tableName  表名称
+     * @throws SQLException SQLException
+     */
+    public void refreshTable(Connection connection, String tableName) throws SQLException {
+        DBTableSerializableHelper helper = new DBTableSerializableHelper(this.getKeyJdbcKey());
+        helper.removeSerialize(tableName);
+        DBScanner dbScanner = new DBScanner(connection, this.properties);
+        DbTable dbTable = dbScanner.scanTable(tableName);
+        if (dbTable != null) {
+            this.updateDbTable(Collections.singletonList(dbTable));
+            this.success();
+        }
+    }
+
+    /**
+     * 全量刷新所有表的元数据
+     *
+     * @param connection 数据库连接
+     * @throws SQLException SQLException
+     */
+    public void refreshAll(Connection connection) throws SQLException {
+        DBScanner dbScanner = new DBScanner(connection, this.properties);
+        List<DbTable> scannedTables = new ArrayList<>(dbScanner.scanAllTables().values());
+        this.tables = scannedTables;
+        this.success();
     }
 }

--- a/src/main/java/com/codingapi/dbstream/scanner/DBScanner.java
+++ b/src/main/java/com/codingapi/dbstream/scanner/DBScanner.java
@@ -79,9 +79,21 @@ public class DBScanner {
      */
     public DBMetaData loadMetadata() throws SQLException {
         DBMetaData dbMetaData = new DBMetaData(info);
-        DatabaseMetaData metaData = connection.getMetaData();
-        String catalog = connection.getCatalog();
-        String schema = connection.getSchema();
+        LinkedHashMap<String, DbTable> tableMap =  this.scanAllTables();
+        dbMetaData.setTables(new ArrayList<>(tableMap.values()));
+        dbMetaData.success();
+        DBMetaContext.getInstance().update(dbMetaData);
+        return dbMetaData;
+    }
+
+
+    /**
+     * 扫描数据库中所有表的元数据，返回列表（不创建新的 DBMetaData 对象）
+     *
+     * @return 所有表的元数据列表
+     * @throws SQLException SQLException
+     */
+    public LinkedHashMap<String, DbTable> scanAllTables() throws SQLException {
         LinkedHashMap<String, DbTable> tableMap = new LinkedHashMap<>();
         ResultSet tables = metaData.getTables(catalog, schema, "%", new String[]{"TABLE"});
         while (tables.next()) {
@@ -92,12 +104,31 @@ public class DBScanner {
             tableMap.put(tableName, tableInfo);
         }
         tables.close();
-        dbMetaData.setTables(new ArrayList<>(tableMap.values()));
-        dbMetaData.success();
-        DBMetaContext.getInstance().update(dbMetaData);
-        return dbMetaData;
+        return tableMap;
     }
 
+    /**
+     * 扫描指定单张表的元数据
+     *
+     * @param tableName 表名称
+     * @return DbTable，若表不存在返回 null
+     * @throws SQLException SQLException
+     */
+    public DbTable scanTable(String tableName) throws SQLException {
+        ResultSet tables = metaData.getTables(catalog, schema, tableName, new String[]{"TABLE"});
+        try {
+            while (tables.next()) {
+                String name = tables.getString("TABLE_NAME");
+                String remarks = tables.getString("REMARKS");
+                DbTable tableInfo = new DbTable(name, remarks);
+                this.loadDbTableInfo(name, tableInfo);
+                return tableInfo;
+            }
+        } finally {
+            tables.close();
+        }
+        return null;
+    }
 
     /**
      * 获取元数据表信息

--- a/src/main/java/com/codingapi/dbstream/serializable/DBTableSerializableHelper.java
+++ b/src/main/java/com/codingapi/dbstream/serializable/DBTableSerializableHelper.java
@@ -79,6 +79,16 @@ public class DBTableSerializableHelper {
     }
 
     /**
+     * 删除指定表的序列化文件
+     */
+    public void removeSerialize(String tableName) {
+        File file = new File(this.path.getPath() + "/" + tableName);
+        if (file.exists()) {
+            file.delete();
+        }
+    }
+
+    /**
      * 是否存在序列化的表数据
      */
     public boolean hasSerialize(String tableName) {

--- a/src/test/java/com/example/dbstream/tests/MetadataRefreshTest.java
+++ b/src/test/java/com/example/dbstream/tests/MetadataRefreshTest.java
@@ -1,0 +1,130 @@
+package com.example.dbstream.tests;
+
+import com.codingapi.dbstream.DBStreamContext;
+import com.codingapi.dbstream.scanner.DBMetaData;
+import com.codingapi.dbstream.scanner.DbTable;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class MetadataRefreshTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private DataSource dataSource;
+
+    private static final String SUFFIX = "_" + System.nanoTime() % 100000;
+
+    /**
+     * 测试 refreshAll 全量刷新后新表能被元数据感知
+     */
+    @Test
+    @Transactional
+    @Rollback(false)
+    @Order(1)
+    void testRefreshAll() throws Exception {
+        String tableName = "T_RA" + SUFFIX;
+        entityManager.createNativeQuery(
+            "CREATE TABLE " + tableName + " (id BIGINT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255))"
+        ).executeUpdate();
+        entityManager.flush();
+
+        List<String> keys = DBStreamContext.getInstance().loadDbKeys();
+        assertFalse(keys.isEmpty(), "应至少有一个数据源");
+        String jdbcKey = keys.get(0);
+
+        DBMetaData metaData = DBStreamContext.getInstance().getMetaData(jdbcKey);
+
+        try (Connection conn = dataSource.getConnection()) {
+            DBStreamContext.getInstance().refreshAll(conn, jdbcKey);
+        }
+
+        DbTable afterRefresh = metaData.getTable(tableName);
+        assertNotNull(afterRefresh, "刷新后新表应在元数据中");
+        assertTrue(afterRefresh.hasPrimaryKeys(), "新表应有主键");
+        assertTrue(afterRefresh.hasColumns(), "新表应有列");
+    }
+
+    /**
+     * 测试 refreshTable 按表名刷新
+     */
+    @Test
+    @Transactional
+    @Rollback(false)
+    @Order(2)
+    void testRefreshTable() throws Exception {
+        String tableName = "T_RT" + SUFFIX;
+        entityManager.createNativeQuery(
+            "CREATE TABLE " + tableName + " (id BIGINT AUTO_INCREMENT PRIMARY KEY, code VARCHAR(100), val VARCHAR(255))"
+        ).executeUpdate();
+        entityManager.flush();
+
+        List<String> keys = DBStreamContext.getInstance().loadDbKeys();
+        String jdbcKey = keys.get(0);
+
+        DBMetaData metaData = DBStreamContext.getInstance().getMetaData(jdbcKey);
+
+        try (Connection conn = dataSource.getConnection()) {
+            DBStreamContext.getInstance().refreshTable(conn, jdbcKey, tableName);
+        }
+
+        DbTable table = metaData.getTable(tableName);
+        assertNotNull(table, "按表名刷新后应存在");
+        assertTrue(table.hasPrimaryKeys());
+    }
+
+    /**
+     * 测试 refreshTable 对已存在的表能更新元数据（新增列）
+     */
+    @Test
+    @Transactional
+    @Rollback(false)
+    @Order(3)
+    void testRefreshTableAlter() throws Exception {
+        String tableName = "T_ALTER" + SUFFIX;
+        entityManager.createNativeQuery(
+            "CREATE TABLE " + tableName + " (id BIGINT AUTO_INCREMENT PRIMARY KEY, col1 VARCHAR(100))"
+        ).executeUpdate();
+        entityManager.flush();
+
+        List<String> keys = DBStreamContext.getInstance().loadDbKeys();
+        String jdbcKey = keys.get(0);
+        DBMetaData metaData = DBStreamContext.getInstance().getMetaData(jdbcKey);
+
+        // 首次刷新，获取初始元数据
+        try (Connection conn = dataSource.getConnection()) {
+            DBStreamContext.getInstance().refreshTable(conn, jdbcKey, tableName);
+        }
+        DbTable before = metaData.getTable(tableName);
+        assertNotNull(before);
+        int columnCountBefore = before.getColumns().size();
+
+        // 新增列
+        entityManager.createNativeQuery(
+            "ALTER TABLE " + tableName + " ADD COLUMN col2 VARCHAR(200)"
+        ).executeUpdate();
+        entityManager.flush();
+
+        // 再次刷新
+        try (Connection conn = dataSource.getConnection()) {
+            DBStreamContext.getInstance().refreshTable(conn, jdbcKey, tableName);
+        }
+
+        DbTable after = metaData.getTable(tableName);
+        assertNotNull(after);
+        assertTrue(after.getColumns().size() > columnCountBefore, "刷新后列数应增加");
+    }
+}


### PR DESCRIPTION
新增 refreshTable/refreshAll 公共 API，支持按表名或全量刷新 DBMetaData 缓存， 使运行时动态创建或修改的表能被业务方手动触发更新后纳入 CDC 事件捕获。

fix #5 